### PR TITLE
ugettext_lazy is deprecated; update to gettext_lazy

### DIFF
--- a/inventree_zpl/zpl_label.py
+++ b/inventree_zpl/zpl_label.py
@@ -13,7 +13,8 @@ https://0int.io/
 import socket
 
 from jinja2 import Template
-from django.utils.translation import ugettext_lazy as _
+#from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from plugin import InvenTreePlugin
 from plugin.mixins import LabelPrintingMixin, SettingsMixin

--- a/inventree_zpl/zpl_label.py
+++ b/inventree_zpl/zpl_label.py
@@ -13,7 +13,6 @@ https://0int.io/
 import socket
 
 from jinja2 import Template
-#from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import gettext_lazy as _
 
 from plugin import InvenTreePlugin


### PR DESCRIPTION
The key `ugettext_lazy` was apparently [deprecated in Django 4.0](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0) and replaced with `gettext_lazy`. 
Trying to add the plugin to Inventree results in an error stating unable to import `ugettext_lazy`.